### PR TITLE
Distrobox hook?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8-alpine
+
+LABEL org.opencontainers.image.title="try_decodings" \
+      org.opencontainers.image.description="Test-fit various ASCII<->binary encodings." \
+      org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONIOENCODING=utf-8
+
+VOLUME /in
+
+COPY . /try_decodings
+
+#ENTRYPOINT [ "/bin/sh", "/try_decodings/docker/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/bin/sh" ]

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ format :
 
 test :
 	python3 try_decodings.py --self-test
+
+distrobox :
+	distrobox create --image python:3.8-alpine --name try_decodings

--- a/readme.rst
+++ b/readme.rst
@@ -25,6 +25,24 @@ For a demonstration, run the self-test::
 
     $ python3 try_decodings.py --selftest | less
 
+Nota bene: This script utilizes the binhex and uu modules that, after thirty 
+years of inclusion, will be completely absent starting sometime during the 
+lifespan of Python 3.  The easiest workaround for both developers and users 
+is probably found in a containerized Python.  This project's makefile now 
+includes a distrobox target that will install a small (<50MB) Alpine Linux 
+container running Pyton 3.8, which predates the deprecation of the required 
+standard library modules.  While "inside" the distrobox, one can interact with
+the script exactly as described earlier without downgrading their native python
+distribution.  Linux users can install Distrobox via their system tools, Windows
+users can use the `Windows Subsystem for Linux`_ 
+
+Assuming Distrobox and a container manager are installed (I recommend Podman), use
+it from the project's directory like this::
+    make distrobox
+    distrobox enter try_decodings 
+
+.. _Windows Subsystem for Linux: https://learn.microsoft.com/en-us/windows/wsl/install
+
 -------
 License
 -------

--- a/tests/uuencode.txt
+++ b/tests/uuencode.txt
@@ -1,0 +1,4 @@
+begin 600 -
+A3F]W(&ES('1H92!T:6UE(&9O<B!A;&P@9V]O9"!M96X*
+`
+end


### PR DESCRIPTION
Hi there,

Thanks for a great project!  Python is removing binhex and uu from the standard library, which is ruinous for this script.  It's not a great situation.  My personal feeling is that the easiest workaround is to run a containerized Python.  Distrobox seems the easiest for command-line tools that want access to local files, so I propose adding a makefile target to create such a container along with some minor amendments to the readme briefly summarizing the new option, its use, and its necessity.

I have also added a uuencode test to the tests directory.

Best regards,
FNG